### PR TITLE
Updated  "CONTRIBUTING.md" link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To run the tests, use the following command:
    ```
 
 ## Contributing
-We welcome contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests.
+We welcome contributions! Please read our [CONTRIBUTING.md](https://github.com/KOSASIH/.github/blob/master/CONTRIBUTING.md#contributing-to-kosasih-project) for details on our code of conduct, and the process for submitting pull requests.
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
The CONTRIBUTING.md link is not working when accessed from the READ.me . 
I tried to link it to where that page actually is in the master branch (there is not one in the main branch).

I'm a bit new to this; I hope this helps.

<img width="1221" height="669" alt="Screenshot 2026-04-03 at 6 33 43 PM" src="https://github.com/user-attachments/assets/ff98b955-a3e6-4967-b779-2605c2863ef9" />


